### PR TITLE
Change LED block hue

### DIFF
--- a/blocks/leds.js
+++ b/blocks/leds.js
@@ -33,7 +33,7 @@ goog.require('Blockly.Blocks');
 /**
  * Common HSV hue for all blocks in this category.
  */
-Blockly.Blocks.leds.HUE = 77;
+Blockly.Blocks.leds.HUE = 20;
 
 Blockly.Blocks['chainable_rgb_led_set'] = {
   init: function() {


### PR DESCRIPTION
Changes LED block HUE to match the hue of the colour blocks, since we'll put them in the same category.