### PR TITLE
Stop trimming color input text in LED generator

### DIFF
--- a/generators/javascript/leds.js
+++ b/generators/javascript/leds.js
@@ -33,6 +33,6 @@ Blockly.JavaScript['chainable_rgb_led_set'] = function(block) {
   console.log(block);
   var ledId = Blockly.JavaScript.valueToCode(block, 'LED_ID', Blockly.JavaScript.ORDER_ATOMIC);
   var colour = Blockly.JavaScript.valueToCode(block, 'COLOUR', Blockly.JavaScript.ORDER_ATOMIC);
-  var code = "setChainableRgbLed(" + ledId + "," + colour.substring(1, colour.length - 1) + ");";
+  var code = "setChainableRgbLed(" + ledId + "," + colour + ");";
   return code;
 };


### PR DESCRIPTION
For some reason, Blockly puts extra parentheses around the result of its color-generating function blocks. Like this:

`setChainableRgbLed(123,(colourRandom()));`

I had some code to trim them out, but didn't notice that it was trimming out the quotes when the color palette returned a raw color.

`setChainableRgbLed(123,#00ff00);`

From playing around in the console, JS doesn't seem to mind the extra parentheses. Maybe Blockly adds them for some good reason. So I'm taking out my trimming logic.