### PR TITLE
Handle missing values in led generator

### DIFF
--- a/generators/javascript/leds.js
+++ b/generators/javascript/leds.js
@@ -33,6 +33,12 @@ Blockly.JavaScript['chainable_rgb_led_set'] = function(block) {
   console.log(block);
   var ledId = Blockly.JavaScript.valueToCode(block, 'LED_ID', Blockly.JavaScript.ORDER_ATOMIC);
   var colour = Blockly.JavaScript.valueToCode(block, 'COLOUR', Blockly.JavaScript.ORDER_ATOMIC);
+  if (!ledId) {
+    ledId = 'null';
+  }
+  if (!colour) {
+    colour = 'null';
+  }
   var code = "setChainableRgbLed(" + ledId + ", " + colour + ");";
   return code;
 };


### PR DESCRIPTION
Handle missing argument blocks so that we get
`setChainableRgbLed(null, null)` instead of
`setChainableRgbLed(,)`