### PR TITLE
Handle motor speed variables

### DIFF
--- a/generators/javascript/motors.js
+++ b/generators/javascript/motors.js
@@ -33,7 +33,12 @@ Blockly.JavaScript['motors_start'] = function(block) {
   var dropdown_motor = block.getFieldValue('MOTOR');
   var dropdown_direction = block.getFieldValue('DIRECTION');
   var value_speed = Blockly.JavaScript.valueToCode(block, 'SPEED', Blockly.JavaScript.ORDER_ATOMIC);
-  var code = "setMotor('"+dropdown_motor+"', '"+dropdown_direction+"', '"+value_speed+"');";
+  var code = "setMotor('" + dropdown_motor + "', '" + dropdown_direction + "'";
+  if (isNaN(parseInt(value_speed))) {
+    code += ", " + value_speed + ".toString());";
+  } else {
+    code += ", '" + value_speed + "');";
+  }
   return code;
 };
 


### PR DESCRIPTION
Closes #8 

If a variable is used, don't put quotes around it and convert it to a string.

Example from browser:
```
var dropdown_motor = 'LEFT';
var dropdown_direction = 'FORWARD';
var code = "setMotor('" + dropdown_motor + "', '" + dropdown_direction + "'";

var value_speed = '100';

if (isNaN(parseInt(value_speed))) {
  code += ", " + value_speed + ".toString());";
} else {
  code += ", '" + value_speed + "');";
}

"setMotor('LEFT', 'FORWARD', '100');"

value_speed = 'i';

if (isNaN(parseInt(value_speed))) {
  code += ", " + value_speed + ".toString());";
} else {
  code += ", '" + value_speed + "');";
}

"setMotor('LEFT', 'FORWARD', i.toString());"
```